### PR TITLE
feat: Add Peer Discovery and Download Resume

### DIFF
--- a/P2P java/PeerDiscoveryService.java
+++ b/P2P java/PeerDiscoveryService.java
@@ -1,0 +1,83 @@
+import java.io.IOException;
+import java.net.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class PeerDiscoveryService {
+
+    private static final int BROADCAST_PORT = 9876;
+    private static final String BROADCAST_ADDRESS = "255.255.255.255";
+    private static final int DISCOVERY_INTERVAL_SECONDS = 30;
+
+    private int myPort;
+    private final Set<String> discoveredPeers = Collections.synchronizedSet(new HashSet<>());
+    private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private DatagramSocket socket;
+
+    public PeerDiscoveryService(int myPort) {
+        this.myPort = myPort;
+    }
+
+    public void start() {
+        try {
+            socket = new DatagramSocket(BROADCAST_PORT, InetAddress.getByName("0.0.0.0"));
+            socket.setBroadcast(true);
+            new Thread(this::listenForPeers).start();
+            scheduler.scheduleAtFixedRate(this::broadcastPresence, 0, DISCOVERY_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        } catch (IOException e) {
+            System.err.println("Error starting peer discovery: " + e.getMessage());
+        }
+    }
+
+    private void broadcastPresence() {
+        try {
+            String message = "PEER:" + myPort;
+            byte[] buffer = message.getBytes();
+            DatagramPacket packet = new DatagramPacket(buffer, buffer.length, InetAddress.getByName(BROADCAST_ADDRESS), BROADCAST_PORT);
+            socket.send(packet);
+        } catch (IOException e) {
+            System.err.println("Error broadcasting presence: " + e.getMessage());
+        }
+    }
+
+    private void listenForPeers() {
+        try {
+            byte[] buffer = new byte[256];
+            while (true) {
+                DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+                socket.receive(packet);
+                String received = new String(packet.getData(), 0, packet.getLength());
+                String[] parts = received.split(":");
+                if (parts.length == 2 && parts[0].equals("PEER")) {
+                    String peerAddress = packet.getAddress().getHostAddress();
+                    int peerPort = Integer.parseInt(parts[1]);
+
+                    // Avoid adding self
+                    if (!peerAddress.equals(InetAddress.getLocalHost().getHostAddress()) || peerPort != myPort) {
+                        discoveredPeers.add(peerAddress + ":" + peerPort);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("Error listening for peers: " + e.getMessage());
+        }
+    }
+
+    public Set<String> getDiscoveredPeers() {
+        return discoveredPeers;
+    }
+
+    public void shutdown() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+        if (socket != null && !socket.isClosed()) {
+            socket.close();
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces two new features: a peer discovery mechanism and the ability to resume downloads. These changes significantly improve the user experience and the reliability of the P2P file sharing application.

How it is done:

Peer Discovery:

A new class, PeerDiscoveryService.java, was created to handle UDP broadcasts.

The service broadcasts the peer's address and port on the local network at regular intervals.

It also listens for broadcasts from other peers, adding them to a list of discovered connections.

The Peer.java main class now starts this service upon initialization and adds a new discover command to the CLI to display the list of found peers.

Download Resume:

The download command logic was modified to first check if a partial file already exists in the downloads directory.

The size of the existing file is sent to the receiving peer as an offset.

The server-side handleDownload method now takes this offset and uses a RandomAccessFile to begin sending the file's binary data from that specific point.

The client-side ConnectionHandler also uses RandomAccessFile to append the new data to the existing file, effectively resuming the download.

How it can be helpful:

Better User Flow: New users can start sharing files much faster without any network configuration.

Error Tolerance: Downloads can now withstand network interruptions without forcing the user to restart from the beginning, which is particularly useful for large files.

Scalability: The framework for peer discovery can be a foundation for more advanced features like a peer list that is automatically updated in the CLI.